### PR TITLE
0.3 fixes and some QoL

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -34,7 +34,7 @@ function waitForApp() {
             // Get the item category
 
             const propertyFilters = staticData.propertyFilters || [];
-            const itemClassFilter = propertyFilters[0].filters;
+            const itemClassFilter = propertyFilters.find(filter => filter.id === 'type_filters')?.filters;
 
             if (!itemClassFilter) {
                 console.error("Error: Could not find item class filter.");

--- a/inject.js
+++ b/inject.js
@@ -104,7 +104,7 @@ function waitForApp() {
 
                 // Handle attribute and elemental resist filter
                 if (event.data.type === "SET_EXPANDED_STAT_FILTER") {
-                    const { humanText, count, min, max } = event.data;
+                    const { humanText, min, max } = event.data;
 
                     const statIds = [];
                     ["Dexterity", "Intelligence", "Strength"].forEach(attr => {
@@ -126,14 +126,13 @@ function waitForApp() {
                     window.app.$store.commit("pushStatGroup", {
                         filters: statIds.map((id) => ({
                             id,
-                            value: { min, max },
                         })),
-                        type: "count",
+                        type: "weight",
                     });
 
                     window.app.$store.commit("setStatGroupValue", {
                         group: newGroupIndex,
-                        value: { min: count },
+                        value: { min, max },
                     });
                 }
 

--- a/inject.js
+++ b/inject.js
@@ -62,12 +62,18 @@ function waitForApp() {
                 // Handle stat filters
                 if (event.data.type === "SET_STAT_FILTER_FROM_TEXT") {
                     const { humanText, min, max } = event.data;
-                    if (!statsMap[humanText]) {
-                        if (DEBUG) console.log(`No matching stat ID found for "${humanText}".`);
+                    
+                    // Remove (desecrated) and (fractured) modifiers. This
+                    // treats them like explicit modifiers. This assumes that an
+                    // explicit mod variant exists for these types of mods.
+                    const cleanText = humanText.replace(/\s*\((desecrated|fractured)\)$/, '');
+                    
+                    if (!statsMap[cleanText]) {
+                        if (DEBUG) console.log(`No matching stat ID found for "${cleanText}".`);
                         return;
                     }
 
-                    const statIds = statsMap[humanText];
+                    const statIds = statsMap[cleanText];
 
                     if (statIds.length > 1) {
                         if (DEBUG) console.log(`Duplicate stat IDs found for "${humanText}":`, statIds);

--- a/inject.js
+++ b/inject.js
@@ -62,18 +62,33 @@ function waitForApp() {
                 // Handle stat filters
                 if (event.data.type === "SET_STAT_FILTER_FROM_TEXT") {
                     const { humanText, min, max } = event.data;
-                    
+
                     // Remove (desecrated) and (fractured) modifiers. This
                     // treats them like explicit modifiers. This assumes that an
                     // explicit mod variant exists for these types of mods.
                     const cleanText = humanText.replace(/\s*\((desecrated|fractured)\)$/, '');
-                    
-                    if (!statsMap[cleanText]) {
-                        if (DEBUG) console.log(`No matching stat ID found for "${cleanText}".`);
-                        return;
+
+                    // Collect stat IDs for the base text and variants
+                    const statIds = [];
+
+                    // Add base stat if it exists
+                    if (statsMap[cleanText]) {
+                        statIds.push(...statsMap[cleanText]);
                     }
 
-                    const statIds = statsMap[cleanText];
+                    // Add variants if they exist
+                    const variants = ['Local', 'Global', 'Jewel'];
+                    for (const variant of variants) {
+                        const variantText = `${cleanText} (${variant})`;
+                        if (statsMap[variantText]) {
+                            statIds.push(...statsMap[variantText]);
+                        }
+                    }
+
+                    if (statIds.length === 0) {
+                        if (DEBUG) console.log(`No matching stat ID found for "${cleanText}" or its variants.`);
+                        return;
+                    }
 
                     if (statIds.length > 1) {
                         if (DEBUG) console.log(`Duplicate stat IDs found for "${humanText}":`, statIds);

--- a/inject.js
+++ b/inject.js
@@ -141,6 +141,10 @@ function waitForApp() {
                         }
                     });
 
+                    if (statIds.length === 0) {
+                        return
+                    }
+
                     const currentStats = window.app.$store.state.persistent.stats;
                     const newGroupIndex = currentStats.length;
 

--- a/popup.html
+++ b/popup.html
@@ -19,13 +19,13 @@
       <input type="checkbox" id="genericAttributes" name="genericAttributes" />
       <label for="genericAttributes">Search All Attribute</label>
       <span
-        data-tooltip="Replaces individual attributes (Str, Dex, Int) with a single count filter that matches any of them.">❔</span>
+        data-tooltip="Replaces individual attributes (Str, Dex, Int) with a sum filter that matches any of them.">❔</span>
     </div>
     <div class="checkbox">
       <input type="checkbox" id="genericElementalResists" name="genericElementalResists" />
       <label for="genericElementalResists">Search All Elemental Resists</label>
       <span class="tooltip-rightfix"
-        data-tooltip="Replaces specific elemental resistances with a count filter for Fire, Cold, and Lightning Res.">❔</span>
+        data-tooltip="Replaces specific elemental resistances with a sum filter for Fire, Cold, and Lightning Res.">❔</span>
     </div>
     <fieldset>
       <legend>

--- a/popup.js
+++ b/popup.js
@@ -111,7 +111,10 @@ document.addEventListener("DOMContentLoaded", () => {
       // Handle ranges (e.g., "Adds 10 to 16 Physical Damage to Attacks")
       if (/(\d+)\s+to\s+(\d+)/.test(cleanedLine)) {
         const humanText = cleanedLine.replace(/(\d+)\s+to\s+(\d+)/g, "# to #");
-        const min = parseFloat(cleanedLine.match(/\d+/)?.[0]); // Use the first number as min
+        const matches = cleanedLine.match(/(\d+)\s+to\s+(\d+)/);
+        const minVal = parseFloat(matches[1]);
+        const maxVal = parseFloat(matches[2]);
+        const min = Math.floor((minVal + maxVal) / 2);
         return { humanText, min };
       }
 

--- a/popup.js
+++ b/popup.js
@@ -154,15 +154,12 @@ document.addEventListener("DOMContentLoaded", () => {
         const modifiedLine = humanText.replace(/Dexterity|Strength|Intelligence/g, "ATTRIBUTES");
         return { humanText: modifiedLine, min };
       })
-      // Dedupe the array, attaching a count.
+      // Dedupe the array, summing the min values.
       .reduce((dict, { humanText, min }) => {
         if (dict[humanText]) {
-          dict[humanText].count += 1;
-          if (min < dict[humanText].min) {
-            dict[humanText].min = min;
-          }
+          dict[humanText].min += min; // Sum the min values
         } else {
-          dict[humanText] = { humanText, min, count: 1 };
+          dict[humanText] = { humanText, min };
         }
         return dict;
       }, {});
@@ -187,20 +184,17 @@ document.addEventListener("DOMContentLoaded", () => {
       parsedStats = other;
 
       const transformedResist = resist.map(({ humanText, min }) => {
-        const modifiedLine = humanText.replace(/Lightning|Cold|Fire/g, "ELEMENTAL_RESIST");
-        return { humanText: modifiedLine, min };
-      })
-      .reduce((dict, { humanText, min }) => {
-        if (dict[humanText]) {
-          dict[humanText].count += 1;
-          if (min < dict[humanText].min) {
-            dict[humanText].min = min;
+          const modifiedLine = humanText.replace(/Lightning|Cold|Fire/g, "ELEMENTAL_RESIST");
+          return { humanText: modifiedLine, min };
+        })
+        .reduce((dict, { humanText, min }) => {
+          if (dict[humanText]) {
+            dict[humanText].min += min; // Sum the min values
+          } else {
+            dict[humanText] = { humanText, min };
           }
-        } else {
-          dict[humanText] = { humanText, min, count: 1 };
-        }
-        return dict;
-      }, {});
+          return dict;
+        }, {});
 
       elementalResists = transformedResist;
     }


### PR DESCRIPTION
* Fix item class filter. Website update for Instant Buyout broke our discovery of the field.
* Support desecrated (and fractured) mods. Treats them as explicit mods.
* Search both Local and Global variants of a mod (lazy solution). Armour now has "#% Increased Armour (Local)". While an amulet would have "#% Increased Armour". The only "(Global)" mod I see is for Charm Slot.
* Use weighted sums instead of count.
* Use average of multiple values. This seems to be what the site uses internally when searching for min values of a damage affix. e.g. "Adds 1-100 Lightning Damage to Attacks" can be filtered by a min value of 50.

See individual commits for the above changes.